### PR TITLE
Fix server name

### DIFF
--- a/proxy/app.conf
+++ b/proxy/app.conf
@@ -1,5 +1,5 @@
 upstream appservers {
-  server ch11coffeeapi_coffee_1:3000;
+  server ch11_coffee_api_coffee_1:3000;
 }
 
 server {


### PR DESCRIPTION
Proxy was constantly crashing with:
`nginx: [emerg] host not found in upstream`